### PR TITLE
1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
 loader_version=0.16.14
 
 # Mod Properties
@@ -14,5 +14,5 @@ maven_group=com.tiji.media
 archives_base_name=media
 
 # Dependencies
-fabric_version=0.121.0+1.21.5
+fabric_version=0.76.1+1.19.3
 modmenu_version=14.0.0-rc.2

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 	},
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.19.1",
+		"minecraft": "~1.19.2",
 		"java": ">=21",
 		"fabric-api": "*",
   "libgui": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,8 +20,8 @@
 		"modmenu": [ "com.tiji.media.ModMenuApiImpl" ]
 	},
 	"depends": {
-		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.19.2",
+		"fabricloader": ">=0.16.14",
+		"minecraft": "~1.19.3",
 		"java": ">=21",
 		"fabric-api": "*",
   "libgui": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 	},
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.19",
+		"minecraft": "~1.19.1",
 		"java": ">=21",
 		"fabric-api": "*",
   "libgui": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 	},
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.21.5",
+		"minecraft": "~1.19",
 		"java": ">=21",
 		"fabric-api": "*",
   "libgui": "*"


### PR DESCRIPTION
## Summary by Sourcery

Downgrade the project from Minecraft version 1.21.5 to 1.19.3, updating corresponding Minecraft dependencies and mappings

New Features:
- Migrated project to Minecraft 1.19.3

Chores:
- Updated Minecraft version from 1.21.5 to 1.19.3
- Updated Yarn mappings to match new Minecraft version
- Updated Fabric and Mod Menu dependencies to version compatible with 1.19.3